### PR TITLE
fix: restore production environment for secrets access

### DIFF
--- a/.github/workflows/deploy-agent.yml
+++ b/.github/workflows/deploy-agent.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: production
     concurrency:
       group: ${{ github.workflow }}-agent
       cancel-in-progress: true


### PR DESCRIPTION
- Keep manual deployment only (no auto-deploy)
- Restore environment: production to load secrets properly
- Fixes: LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET must be set error